### PR TITLE
Upgrade Java, Node, Artifact Registry

### DIFF
--- a/cloudbuild.yaml
+++ b/cloudbuild.yaml
@@ -13,13 +13,13 @@ steps:
         git fetch origin
         git checkout $BRANCH_NAME
         git reset --hard $COMMIT_SHA
-  - name: "gcr.io/$PROJECT_ID/npm-with-java8"
+  - name: "gcr.io/$PROJECT_ID/npm-with-java"
     args: ["install"]
-  - name: "gcr.io/$PROJECT_ID/npm-with-java8"
+  - name: "gcr.io/$PROJECT_ID/npm-with-java"
     args: ["run", "build"]
-  - name: "gcr.io/$PROJECT_ID/npm-with-java8"
+  - name: "gcr.io/$PROJECT_ID/npm-with-java"
     args: ["test"]
-  - name: "gcr.io/$PROJECT_ID/npm-with-java8"
+  - name: "gcr.io/$PROJECT_ID/npm-with-java"
     args: ["run", "semantic-release"]
     secretEnv: ["GH_TOKEN", "NPM_TOKEN"]
 secrets:

--- a/spec/README.md
+++ b/spec/README.md
@@ -11,7 +11,6 @@ Other than npm dependencies, the local version of firebase installed with `@fire
 To test in Cloud Build, the docker image needs both npm and java installed. [docker/Dockerfile](docker/Dockerfile) specifies how to create such an image, and you can use Cloud Build to publish the image by running
 
 ```
+export CLOUDSDK_CORE_PROJECT=firesocket-test
 gcloud builds submit --config cloudbuild.yaml .
 ```
-
-- [ ] TODO Container Registry will be phased out, starting May 15, 2024. Please review the options below for how to upgrade your projects to Artifact Registry.

--- a/spec/docker/Dockerfile
+++ b/spec/docker/Dockerfile
@@ -1,11 +1,9 @@
-FROM node:16
+FROM node:18-slim
 
-# https://stackoverflow.com/a/44058196/771768
-RUN apt-get update && \
-    apt-get install -y openjdk-11-jre-headless && \
-    apt-get clean
-
-ENV JAVA_HOME /usr/lib/jvm/java-8-openjdk-amd64/
-RUN export JAVA_HOME
+RUN apt-get update \
+    && apt-get install -y --no-install-recommends \
+        default-jre \
+        git \
+    && rm -rf /var/lib/apt/lists/*
 
 ENTRYPOINT ["npm"]

--- a/spec/docker/README.md
+++ b/spec/docker/README.md
@@ -1,0 +1,10 @@
+For more context, see [parent README](../README.md).
+
+Build and test installed versions
+
+```bash
+docker build -t npm-with-java .
+docker run --rm npm-with-java --version
+docker run --rm --entrypoint node npm-with-java --version
+docker run --rm --entrypoint java npm-with-java --version
+```

--- a/spec/docker/cloudbuild.yaml
+++ b/spec/docker/cloudbuild.yaml
@@ -1,5 +1,5 @@
 steps:
   - name: "gcr.io/cloud-builders/docker"
-    args: ["build", "-t", "gcr.io/$PROJECT_ID/npm-with-java8", "."]
+    args: ["build", "-t", "gcr.io/$PROJECT_ID/npm-with-java", "."]
 images:
-  - "gcr.io/$PROJECT_ID/npm-with-java8" # TODO Container Registry will be phased out, starting May 15, 2024. Please review the options below for how to upgrade your projects to Artifact Registry.
+  - "gcr.io/$PROJECT_ID/npm-with-java"


### PR DESCRIPTION
Container Registry is deprecated and scheduled for shutdown.
Following guide https://cloud.google.com/artifact-registry/docs/transition/transition-from-gcr

Might unblock #69

Ran `gcloud artifacts docker upgrade migrate` a lot, so we redirect gcr.io now.
Published new docker image with https://console.cloud.google.com/cloud-build/builds/db650d17-8639-42fb-be5b-38b1641dd739?project=303747709802